### PR TITLE
Pass options to swig.setDefaults

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ module.exports = function(options){
   'use strict';
 
   var opts = options ? clone(options) : {};
+  swig.setDefaults(opts)
 
   function gulpswig(file, callback){
 
@@ -28,7 +29,7 @@ module.exports = function(options){
       var json = JSON.parse(fs.readFileSync(jsonPath));
       data = extend(json, data);
     }
-    
+
     var newFile = clone(file);
     var tpl = swig.compileFile(file.path);
     var compiled = tpl(data);


### PR DESCRIPTION
swig cache is enabled by default.  If you use this plugin with gulp.watch, it won't pick up on HTML changes.

with this change you can pass `{cache:false}` and other options thru to swig...

``` js
gulp.src('./src/*.html')
    .pipe(swig({load_json: true, cache: false}))
    .pipe(gulp.dest('./dist/'))
```
