### PR TITLE
Allowing data to be set from a callback per file.

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,10 @@ module.exports = function(options){
 
     var data = opts.data || {};
 
+    if (typeof data === 'function') {
+      data = data(file);
+    }
+
     if (opts.load_json === true) {
       var jsonPath = ext(file.path, '.json');
       var json = JSON.parse(fs.readFileSync(jsonPath));

--- a/test/test.js
+++ b/test/test.js
@@ -62,6 +62,20 @@ describe('gulp-swig compilation', function(){
         .pipe(expectStream(done, opts));
     });
 
+    it('should compile my swig files into HTML with data callback', function(done){
+      var opts = {
+        data : function (file) {
+          return {
+            message1 : path.basename(file.path)
+          };
+        },
+        expected : '<div class="layout">test.html</div>'
+      };
+      gulp.src(filename)
+        .pipe(task(opts))
+        .pipe(expectStream(done, opts));
+    });
+
   });
 
 });


### PR DESCRIPTION
This is an alternate solution to #2.

This allows you to define a callback for the `data` option which will be called per file.

``` js
function getTemplateDataForFile (file) {
    return {
        some_property : file.propertySetByAnotherTask,
        STATIC_URL : path.relative(file.base, pathToStaticAssets)
    };
}
gulp.src('*.html')
    .pipe(swig({
        data : getTemplateDataForFile
    }))
```
