### PR TITLE
bump swig version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "event-stream": "~3.0.15",
     "clone": "~0.1.9",
     "gulp-util": "~2.2.14",
-    "swig": "~1.1.0",
+    "swig": "~1.3.0",
     "gulp": "~3.5.1"
   },
   "main": "index.js",


### PR DESCRIPTION
Any chance we can bump the package.json to use a newer version of SWIG? Tests all pass still. There seems to have been some updates with the template loaders between ~1.1.0 and ~1.3.0. I'm not sure you could set additional template paths in ~1.1.0. I've been using `npm shrinkwrap` to overcome this but I figure it makes sense for this to make its way back into the official project.
