### PR TITLE
adding way to manually define json

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = function(options) {
       if (opts.json_path) {
         jsonPath = path.join(opts.json_path, ext(path.basename(file.path), '.json'));
       } else {
-        jsonPath = ext(file.path, '.json');
+        jsonPath = opts.jsonPath || ext(file.path, '.json');
       }
 
       // skip error if json file doesn't exist


### PR DESCRIPTION
I needed a way to manually define the json used, instead of relying on the filename, so this checks to see if jsonPath is defined, and if not it reverts to using the template filename.
