### PR TITLE
Continue on compile errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,14 +59,18 @@ module.exports = function(options) {
       } catch (err) {}
     }
 
-    var newFile = clone(file);
-    var tpl = swig.compile(String(file.contents), {filename: file.path});
-    var compiled = tpl(data);
+    try {
+      var tpl = swig.compile(String(file.contents), {filename: file.path});
+      var compiled = tpl(data);
 
-    newFile.path = ext(newFile.path, opts.ext);
-    newFile.contents = new Buffer(compiled);
+      file.path = ext(file.path, opts.ext);
+      file.contents = new Buffer(compiled);
 
-    callback(null, newFile);
+      callback(null, file);
+    } catch (err) {
+      callback(new PluginError('gulp-swig', err));
+      callback();
+    }
   }
 
   return es.map(gulpswig);


### PR DESCRIPTION
Hi, I'm running task asynchronously by returning stream like described here https://github.com/gulpjs/gulp/blob/master/docs/API.md#return-a-stream.

And when there's some syntax or other errors, gulp exits with unhandled error.
That's a fix for that situation. With that it can show errors (using plumber, for example) and continue watching for changes.
