### PR TITLE
Make empty string a valid extension option

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = function(options) {
   'use strict';
 
   var opts = options ? clone(options) : {};
-  opts.ext = opts.ext || ".html";
+  opts.ext = opts.ext != null ? opts.ext : ".html";
 
   if (opts.defaults) {
     swig.setDefaults(opts.defaults);


### PR DESCRIPTION
I have a use case of gulp-swig where I use a `.swig` extension on the input files...something like `template.html.swig`.  I would like gulp-swig to be able to just remove the extension entirely--i.e. use an empty string for `opts.ext`.  An empty string, however, is falsy, and so this pull request addresses my use case.  The current behavior is mostly unchanged, as the default `.html` extension is still applied if `opts.ext` is `null` or `undefined`.
