### PR TITLE
feature(precompile): allow for precompilation

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,8 +60,33 @@ module.exports = function(options) {
     }
 
     try {
-      var tpl = swig.compile(String(file.contents), {filename: file.path});
-      var compiled = tpl(data);
+      var compiled;
+
+      if (opts.precompile) {
+        var preTpl = swig.precompile(String(file.contents), {filename: file.path});
+        var templateText = preTpl.tpl.toString();
+
+        if (typeof opts.precompile === "string") {
+          var gutilOpts = {
+            template: templateText,
+            file: {
+              path: file.path,
+              name: path.basename(file.path),
+              basename: path.basename(file.path, path.extname(file.path)),
+              ext: path.extname(file.path)
+            }
+          };
+
+          compiled = gutil.template(opts.precompile, gutilOpts);
+        }
+        else {
+          compiled = templateText;
+        }
+      }
+      else {
+        var tpl = swig.compile(String(file.contents), {filename: file.path});
+        compiled = tpl(data);
+      }
 
       file.path = ext(file.path, opts.ext);
       file.contents = new Buffer(compiled);


### PR DESCRIPTION
I've added an option to allow precompilation. Simply setting this to true will create a file with the precompilation function in it. Specifying a string on the other hand considers this a lodash template which is compiled using gutil.template. This allows for things like "module.exports = <%= template %>" to create modules from templates. Alternatively some magic can be done with gulp-concat to let users create a single module from all their templates.

The reason I want this function is because my data is not static but I would like to use swig. By supporting this function from swig I can precompile my templates. Use them on the server or send them to the browser with dynamically loaded data.

Possible future additions could be turning options.precompile into an object with a glob. Only files matching the globs would be precompiled, the rest could be compiled to static HTML. This is however more than I need at the moment and probably more confusing than my current solution.

As per the swig documentation, any function resulting from `opts.precompile = true` or `opts.precompile = "<%= template %>" should be used with `swig.run`.