### PR TITLE
Add new Swig env compiler for varControls

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,9 @@ module.exports = function(options) {
     }
 
     try {
-      var tpl = swig.compile(String(file.contents), {filename: file.path});
+
+      var _swig = opts.varControls ? new swig.Swig(opts) : swig;
+      var tpl = _swig.compile(String(file.contents), {filename: file.path});
       var compiled = tpl(data);
 
       file.path = ext(file.path, opts.ext);

--- a/test/fixtures/test5.html
+++ b/test/fixtures/test5.html
@@ -1,0 +1,1 @@
+{{@test message1 }}

--- a/test/test.js
+++ b/test/test.js
@@ -17,6 +17,7 @@ describe('gulp-swig compilation', function() {
     var filename_without_layout = path.join(__dirname, './fixtures/test2.html');
     var filename_without_json = path.join(__dirname, './fixtures/test4.html');
     var filename_with_markdown = path.join(__dirname, './fixtures/test3.html');
+    var filename_with_varControls = path.join(__dirname, './fixtures/test5.html');
 
     function expectStream(done, options) {
       options = options || {};
@@ -120,6 +121,19 @@ describe('gulp-swig compilation', function() {
         expected: '<p><strong>hello</strong><br>world</p>\n'
       };
       gulp.src(filename_with_markdown)
+        .pipe(task(opts))
+        .pipe(expectStream(done, opts));
+    });
+
+    it('should compile custom varControls', function(done) {
+      var opts = {
+        varControls: ['{{@test', '}}'],
+        data:{
+          message1:'Hello'
+        },
+        expected: 'Hello\n'
+      };
+      gulp.src(filename_with_varControls)
         .pipe(task(opts))
         .pipe(expectStream(done, opts));
     });


### PR DESCRIPTION
This is probably a monkey patch and possibly an issue with Swig. When using multiple varControls I need to use the swig.Swig() method to create a separate rendering environment. Tried to convert my native use of the swig module to gulp and ran into the same issue. This is my attempt at a remedy. Love to hear your thoughts. Is there a better way to solve this?