### PR TITLE
Added option to not extend file.data.

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,11 @@ module.exports = function(options) {
     }
 
     if (file.data) {
-      data = extend(file.data, data);
+      if(opts.extend_filedata !== false) {
+        data = extend(file.data, data);
+      } else {
+        data.filedata = file.data
+      }
     }
 
     if (opts.load_json === true) {


### PR DESCRIPTION
When using an auto generated json file such as the manifest from a cache buster, the generated keys may not be valid variable names in Swig.

    {"js/script.js":"js/script.da39a3ee.js"}

To overcome this, a new option `extend_filedata` has been added. When set to `false` it sets `file.data` to `data.filedata` instead of extending `data`.  This allows a user to use bracket-notation to access the invalid variable in Swig.

    {{ filedata['js/script.js'] }}

By default `extend_filedata` is `true`.