### PR TITLE
Use file ext from stream by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,6 @@ module.exports = function(options) {
   'use strict';
 
   var opts = options ? clone(options) : {};
-  opts.ext = opts.ext || ".html";
 
   if (opts.defaults) {
     swig.setDefaults(opts.defaults);
@@ -65,7 +64,7 @@ module.exports = function(options) {
       var tpl = _swig.compile(String(file.contents), {filename: file.path});
       var compiled = tpl(data);
 
-      file.path = ext(file.path, opts.ext);
+      file.path = opts.ext ? ext(file.path, opts.ext) : file.path;
       file.contents = new Buffer(compiled);
 
       callback(null, file);

--- a/test/fixtures/test.css
+++ b/test/fixtures/test.css
@@ -1,0 +1,1 @@
+body { color: white; }

--- a/test/test.js
+++ b/test/test.js
@@ -18,6 +18,7 @@ describe('gulp-swig compilation', function() {
     var filename_without_json = path.join(__dirname, './fixtures/test4.html');
     var filename_with_markdown = path.join(__dirname, './fixtures/test3.html');
     var filename_with_varControls = path.join(__dirname, './fixtures/test5.html');
+    var filename_different_ext = path.join(__dirname, './fixtures/test.css');
 
     function expectStream(done, options) {
       options = options || {};
@@ -25,6 +26,10 @@ describe('gulp-swig compilation', function() {
         var result = String(file.contents);
         var expected = options.expected;
         expect(result).to.equal(expected);
+        if (options.expectedExt) {
+          var expectedExt = options.expectedExt;
+          expect(path.extname(file.path)).to.equal(expectedExt);
+        }
         done();
       });
     }
@@ -138,6 +143,28 @@ describe('gulp-swig compilation', function() {
         .pipe(expectStream(done, opts));
     });
 
+    it('should use the file extension from the stream by default', function(done) {
+      var opts = {
+        load_json: true,
+        expected: 'body { color: white; }\n',
+        expectedExt: '.css'
+      };
+      gulp.src(filename_different_ext)
+          .pipe(task(opts))
+          .pipe(expectStream(done, opts));
+    });
+
+    it('should use the file extension from opts.ext instead of the stream', function(done) {
+      var opts = {
+        ext: '.less',
+        load_json: true,
+        expected: 'body { color: white; }\n',
+        expectedExt: '.less'
+      };
+      gulp.src(filename_different_ext)
+          .pipe(task(opts))
+          .pipe(expectStream(done, opts));
+    });
   });
 
 });


### PR DESCRIPTION
I noticed that gulp-swig currently uses ".html" for every file extension unless explicitly configured to do otherwise. Ideally, it would just use the file extension from the given file stream by default but also have the ability to override that file extension. 