### PR TITLE
Remove gulp-util dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "clone": "~2.1.2",
     "event-stream": "~4.0.1",
-    "gulp-util": "~3.0.8",
     "plugin-error": "^1.0.1",
     "replace-ext": "^1.0.0",
     "swig-templates": "^2.0.3"


### PR DESCRIPTION
Remove `gulp-util` from dependencies because it is no longer needed.